### PR TITLE
mkdocs-material version8.xでタブ拡張機能の設定方法が変わったため修正

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,8 @@ plugins:
 
 markdown_extensions:
   - attr_list  # 画像のalignを設定できる
-  - pymdownx.tabbed  # タブで文章を切り替えられる
+  - pymdownx.tabbed:  # タブで文章を切り替えられる
+      alternate_style: true
   - pymdownx.keys  # キーボード操作説明時のキーを装飾
   - admonition  # Warningとかの飾り付けができる
   - pymdownx.highlight  # コードブロック用


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

タブ表示が崩れていたため、それを修正します。

修正前：
![image](https://user-images.githubusercontent.com/18494952/150712612-03d35ae0-8d83-4a47-b514-16357b0706f4.png)

修正後：
![image](https://user-images.githubusercontent.com/18494952/150712632-405c42cd-6c35-4a55-b045-9bc03c11f52c.png)


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

preview.shを実行して、タブ表示が修正されたことを確認しました。


# Any other comments?
<!-- その他コメントはありますか？ -->

下記ページにmkdocs-materialのVersion 7.xから8.xへの変更点が記載されています。

https://squidfunk.github.io/mkdocs-material/upgrade/#upgrading-from-7x-to-8x

`mkdocs.yml`に関わる影響は、tab拡張機能以外には無いと思います。

`*.html`に関わる影響は確認できてません。
ページフッターは変わっていないように見えます。
ページヘッダーは、ページタイトルが`RT Corporation Software Tutorials`から変わらないページがあります。（v7.xからの仕様かもしれませんが）

![image](https://user-images.githubusercontent.com/18494952/150713312-a0308310-fdd8-48ca-b501-63eebf107786.png)


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
