### PR TITLE
[Raspberry Pi Mouse]ROS 2 Jazzyのインストールコマンドの置き換え

### DIFF
--- a/docs/raspimouse/ros/package-install.md
+++ b/docs/raspimouse/ros/package-install.md
@@ -75,36 +75,10 @@ robot: Raspberry Pi Mouse
     * [rt_usb_9axisimu_driver](https://github.com/rt-net/rt_usb_9axisimu_driver/tree/ros2-devel) : 9軸IMU制御パッケージ
 
 === "ROS 2 Jazzy"
-    Raspberry Piとノートパソコン等のPCそれぞれで、次のコマンドを実行します。
-
-    Raspberry Pi Mouseのパッケージをダウンロードします。
-    
-    ```sh
-    $ source /opt/ros/jazzy/setup.bash
-    $ mkdir -p ~/ros2_ws/src
-    $ cd ~/ros2_ws/src
-
-    # Download packages
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse2.git
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse_ros2_examples.git
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
-
-    # Install dependencies
-    $ rosdep install -r -y --from-paths . --ignore-src
-    ```
-
-    Raspberry Pi Mouseのパッケージをビルドします。Raspberry Pi MouseとPCでコマンドが異なります。
+    Raspberry Piとノートパソコン等のPCそれぞれで次のコマンドを実行します。
 
     ```sh
-    # Raspberry Pi Mouseの場合
-    $ cd ~/ros2_ws
-    $ MAKEFLAGS=-j1 colcon build --symlink-install
-    $ source ~/ros2_ws/install/setup.bash
-
-    # PCの場合
-    $ cd ~/ros2_ws
-    $ colcon build --symlink-install
-    $ source ~/ros2_ws/install/setup.bash
+    $ sudo apt install ros-humble-raspimouse-slam-navigation
     ```
 
     これにより、以下のパッケージがインストールされます。

--- a/docs/raspimouse/ros/package-install.md
+++ b/docs/raspimouse/ros/package-install.md
@@ -78,7 +78,7 @@ robot: Raspberry Pi Mouse
     Raspberry Piとノートパソコン等のPCそれぞれで次のコマンドを実行します。
 
     ```sh
-    $ sudo apt install ros-humble-raspimouse-slam-navigation
+    $ sudo apt install ros-jazzy-raspimouse-slam-navigation
     ```
 
     これにより、以下のパッケージがインストールされます。

--- a/docs/raspimouse/ros/samples.md
+++ b/docs/raspimouse/ros/samples.md
@@ -50,22 +50,18 @@ robot: Raspberry Pi Mouse
 
 === "ROS 2 Humble"
     [ROS 2サンプル集(rt-net/raspimouse_ros2_examples)](https://github.com/rt-net/raspimouse_ros2_examples){target=_blank rel=noopener}
-    のサンプルを実行する場合は下記コマンドを実行し、
-    ROS 2とパッケージを読み込んでください。
+    のサンプルを実行する場合は下記コマンドを実行し、ROS 2の設定を読み込んでください。
 
     ```sh
     $ source /opt/ros/humble/setup.bash
-    $ source ~/ros2_ws/install/setup.bash
     ```
 
 === "ROS 2 Jazzy"
     [ROS 2サンプル集(rt-net/raspimouse_ros2_examples)](https://github.com/rt-net/raspimouse_ros2_examples){target=_blank rel=noopener}
-    のサンプルを実行する場合は下記コマンドを実行し、
-    ROS 2とパッケージを読み込んでください。
+    のサンプルを実行する場合は下記コマンドを実行し、ROS 2の設定を読み込んでください。
 
     ```sh
     $ source /opt/ros/jazzy/setup.bash
-    $ source ~/ros2_ws/install/setup.bash
     ```
     
 ## Raspberry PiとPC間のROSネットワークを接続する {: #network}

--- a/docs/raspimouse/simulator/install.md
+++ b/docs/raspimouse/simulator/install.md
@@ -58,6 +58,12 @@ Raspberry Pi Mouse Simulator（[rt-net/raspimouse_sim](https://github.com/rt-net
 === "ROS 2 Humble"
     次のコマンドを実行します。
 
+    下記コマンドを実行し、ROS 2の設定を読み込んでください。
+
+    ```sh
+    source /opt/ros/humble/setup.bash
+    ```
+
     シミュレータパッケージのインストール
 
     ```sh
@@ -78,27 +84,23 @@ Raspberry Pi Mouse Simulator（[rt-net/raspimouse_sim](https://github.com/rt-net
 
 === "ROS 2 Jazzy"
     次のコマンドを実行します。
-    
-    シミュレータパッケージとサンプルパッケージのダウンロードとインストール
-    
+
+    下記コマンドを実行し、ROS 2の設定を読み込んでください。
+
     ```sh
-    $ source /opt/ros/jazzy/setup.bash
-    $ mkdir -p ~/ros2_ws/src
-    $ cd ~/ros2_ws/src
+    source /opt/ros/jazzy/setup.bash
+    ```
 
-    # Download packages
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse_sim.git
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse2.git
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse_ros2_examples.git
-    $ git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+    シミュレータパッケージのインストール
 
-    # Install dependencies
-    $ rosdep install -r -y --from-paths . --ignore-src
+    ```sh
+    sudo apt install ros-$ROS_DISTRO-raspimouse-sim
+    ```
 
-    # make & install
-    $ cd ~/ros2_ws
-    $ colcon build --symlink-install
-    $ source ~/ros2_ws/install/setup.bash
+    サンプルパッケージのインストール
+
+    ```sh
+    sudo apt install ros-$ROS_DISTRO-raspimouse-slam-navigation
     ```
 
     キーボードで操作するためのパッケージをインストール

--- a/docs/raspimouse/simulator/install.md
+++ b/docs/raspimouse/simulator/install.md
@@ -58,55 +58,43 @@ Raspberry Pi Mouse Simulator（[rt-net/raspimouse_sim](https://github.com/rt-net
 === "ROS 2 Humble"
     次のコマンドを実行します。
 
-    下記コマンドを実行し、ROS 2の設定を読み込んでください。
-
-    ```sh
-    source /opt/ros/humble/setup.bash
-    ```
-
     シミュレータパッケージのインストール
 
     ```sh
-    sudo apt install ros-$ROS_DISTRO-raspimouse-sim
+    sudo apt install ros-humble-raspimouse-sim
     ```
 
     サンプルパッケージのインストール
 
     ```sh
-    sudo apt install ros-$ROS_DISTRO-raspimouse-slam-navigation
+    sudo apt install ros-humble-raspimouse-slam-navigation
     ```
 
     キーボードで操作するためのパッケージをインストール
 
     ```sh
-    sudo apt install ros-$ROS_DISTRO-teleop-twist-keyboard
+    sudo apt install ros-humble-teleop-twist-keyboard
     ```
 
 === "ROS 2 Jazzy"
     次のコマンドを実行します。
 
-    下記コマンドを実行し、ROS 2の設定を読み込んでください。
-
-    ```sh
-    source /opt/ros/jazzy/setup.bash
-    ```
-
     シミュレータパッケージのインストール
 
     ```sh
-    sudo apt install ros-$ROS_DISTRO-raspimouse-sim
+    sudo apt install ros-jazzy-raspimouse-sim
     ```
 
     サンプルパッケージのインストール
 
     ```sh
-    sudo apt install ros-$ROS_DISTRO-raspimouse-slam-navigation
+    sudo apt install ros-jazzy-raspimouse-slam-navigation
     ```
 
     キーボードで操作するためのパッケージをインストール
 
     ```sh
-    sudo apt install ros-$ROS_DISTRO-teleop-twist-keyboard
+    sudo apt install ros-jazzy-teleop-twist-keyboard
     ```
 
 ## 動作確認（キーボードで操縦） {: #teleop}


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

Rapsberry Pi MouseのROS 2 Jazzy向けにインストールするパッケージを、GitHubリポジトリからROS Buildfarmからのバイナリパッケージに置き換えます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

Raspberry Pi Mouse V3実機+PCとシミュレータの両方で動作を確認しました。

チュートリアルの見栄えを[Build and browse tutorials](https://github.com/rt-net/tutorials?tab=readme-ov-file#build-and-browse-tutorials)の手順で構築して確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
