### PR TITLE
[Raspberry Pi Mouse]Raspberry Pi OSのカーネルヘッダーインストール手順の更新

### DIFF
--- a/docs/raspimouse/driver/install.md
+++ b/docs/raspimouse/driver/install.md
@@ -168,23 +168,27 @@ Raspberry Pi Mouseのデバイスドライバのソースファイルは
 === "Raspberry Pi OS"
     1. ターミナル(`LXTerminal`)を起動します
     ![](../../img/raspimouse/driver/open_terminal.png)
-    2. 次のコマンドを実行し、デバイスドライバをダウンロードします
+    2. 次のコマンドを実行し、パッケージ情報を最新の状態に更新します
+    ```sh
+    $ sudo apt update
+    ```
+    3. 次のコマンドを実行し、デバイスドライバをダウンロードします
     ```sh
     $ git clone https://github.com/rt-net/RaspberryPiMouse.git
     ```
-    3. 次のコマンドを実行し、Raspberry Pi Mouseを動かすための設定を行います
+    4. 次のコマンドを実行し、Raspberry Pi Mouseを動かすための設定を行います
     ```sh
     $ cd RaspberryPiMouse/utils
     $ ./set_configs.bash
     ```
-    4. Raspberry Piを再起動します
-    5. 次のコマンドを実行し、デバイスドライバをインストールします
+    5. Raspberry Piを再起動します
+    6. 次のコマンドを実行し、デバイスドライバをインストールします
     ```sh
     $ cd RaspberryPiMouse/utils
-    $ sudo apt install raspberrypi-kernel-headers build-essential
+    $ sudo apt install linux-headers-$(uname -r) build-essential
     $ ./build_install.bash
     ```
-    6. コマンド実行後にブザーが鳴ればインストール完了です
+    7. コマンド実行後にブザーが鳴ればインストール完了です
 
 **デバイスドライバはOSを起動するたびにインストールしてください。** 上記インストール手順で設定した場合は以下のコマンドでインストールできます。
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

Raspberry Pi OS (Bookworm以降) で raspberrypi-kernel-headers パッケージが廃止（名称変更）されたことにより、セットアップが失敗する問題を修正しました。

Raspberry Pi 公式ドキュメント: https://www.raspberrypi.com/documentation/computers/linux_kernel.html#kernel-headers
参考issue: https://github.com/raspberrypi/linux/issues/6002

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
Raspberry Pi Mouse V3 (4GB) 実機で動作確認をしました。
- Raspberry Pi Imager 2.0.7
- Raspberry Pi OS (kernel: 6.12.75+rpt-rpi-v8)

# Any other comments?
<!-- その他コメントはありますか？ -->

`sudo apt update`コマンドが抜けていたので同時に追加してます。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
